### PR TITLE
Fix ignored ServerName

### DIFF
--- a/Source/EasyNetQ/Persistent/PersistentConnection.cs
+++ b/Source/EasyNetQ/Persistent/PersistentConnection.cs
@@ -187,7 +187,7 @@ public class PersistentConnection : IPersistentConnection
             CertificateValidationCallback = option.CertificateValidationCallback,
             CheckCertificateRevocation = option.CheckCertificateRevocation,
             Enabled = option.Enabled,
-            ServerName = host,
+            ServerName = option.ServerName ?? host,
             Version = option.Version,
         };
 }


### PR DESCRIPTION
Custom ServerName set in ConnectionConfiguration.Ssl is ignored. This PR fixes the issue.